### PR TITLE
correct dashboard default time interval

### DIFF
--- a/configs/monitoring/dashboard.json
+++ b/configs/monitoring/dashboard.json
@@ -871,8 +871,8 @@
     ]
   },
   "time": {
-    "from": "2022-03-22T21:54:09.098Z",
-    "to": "2022-03-22T21:56:54.439Z"
+    "from": "now-15m",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [


### PR DESCRIPTION
Display last 15min in grafana dashboard by default so users don't have to change it after login