### PR TITLE
fix: bump Flask version to 3.0.0 to fix 'ImportError' issue with werkzeug deps

### DIFF
--- a/auth/service/Dockerfile
+++ b/auth/service/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-alpine
 
-RUN pip3 install -q Flask==2.0.3
+RUN pip3 install -q Flask==3.0.0
 COPY . ./app
 CMD ["python3", "/app/service/server.py"]

--- a/upstream/service/Dockerfile
+++ b/upstream/service/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-alpine
 
-RUN pip3 install -q Flask==2.0.3
+RUN pip3 install -q Flask==3.0.0
 COPY . ./app
 CMD ["python3", "/app/service/server.py"]


### PR DESCRIPTION
While running through the envoy basic workshop, I noticed that the `upstream` and `auth` services are not running.
Did some troubleshooting and found this error in their logs:
```python
Traceback (most recent call last):
  File "/app/service/server.py", line 1, in <module>
    from flask import Flask, request, abort
  File "/usr/local/lib/python3.12/site-packages/flask/__init__.py", line 7, in <module>
    from .app import Flask as Flask
  File "/usr/local/lib/python3.12/site-packages/flask/app.py", line 28, in <module>
    from . import cli
  File "/usr/local/lib/python3.12/site-packages/flask/cli.py", line 18, in <module>
    from .helpers import get_debug_flag
  File "/usr/local/lib/python3.12/site-packages/flask/helpers.py", line 16, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.12/site-packages/werkzeug/urls.py). Did you mean: 'unquote'?
```

Following [this](https://stackoverflow.com/a/77222063/5141899) solution, I tested locally and with the latest Flask version (3.0.0) - the flask APIs came up successfully.

Suggesting a fix so that other folks won't have this issue.

Thanks! 